### PR TITLE
ticket/PREOPS-5243: Update default yaml parameters and error checking

### DIFF
--- a/nightly/FBS_Targets.ipynb
+++ b/nightly/FBS_Targets.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "# This cell is only for setting example parameter defaults - gets replaced by sidecar.\n",
-    "day_obs = \"2024-08-20\"\n",
+    "day_obs = \"2024-08-21\"\n",
     "#day_obs = \"Today\"\n",
     "telescope = \"AuxTel\"  \n",
     "#telescope = \"SimonyiTel\"\n",
@@ -58,8 +58,18 @@
     "\n",
     "import datetime\n",
     "import pytz\n",
-    "tz = pytz.timezone(timezone)\n",
-    "tz_utc = pytz.timezone(\"UTC\")\n",
+    "\n",
+    "import datetime\n",
+    "from zoneinfo import ZoneInfo\n",
+    "\n",
+    "try:\n",
+    "    tz = ZoneInfo(timezone)\n",
+    "    tz_utc = ZoneInfo(\"UTC\")\n",
+    "except ZoneInfoNotFoundError:\n",
+    "    print(\"Timezone should be a string recognizable to `ZoneInfo`.\")\n",
+    "    print(\"Using Chile/Continental (+UTC) backup.\")\n",
+    "    tz = ZoneInfo(\"Chile/Continental\")\n",
+    "    tz_utc = ZoneInfo(\"UTC\")\n",
     "\n",
     "from rubin_scheduler.site_models import Almanac\n",
     "from rubin_scheduler.utils import Site\n",
@@ -891,22 +901,6 @@
     "        print(f\"Date invalidated {row['date_invalidated']}\")\n",
     "    print('\\n')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c05c5137-f748-4687-ac5a-a66c239e2b1d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1745c6d1-d10f-4953-b7a5-a761008af1b8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nightly/FBS_Targets.yaml
+++ b/nightly/FBS_Targets.yaml
@@ -18,9 +18,9 @@ parameters:
     default: "latiss"
   salindex:
     type: integer
-    description: "Sal index to check for EFD Targets and Observations"
+    description: "Sal index to check for EFD Targets and Observations (1/2/3)"
     default: 2
   timezone:
     type: string
     description: "Timezone for plot"
-    default: "UTC"
+    default: "Chile/Continental"


### PR DESCRIPTION
It was too easy to forget the proper string for Chilean timezone. 
And also I swapped to ZoneInfo, instead of pytz (part of python>3.9). 