### PR TITLE
SP-1782: Use date_added 

### DIFF
--- a/nightly/EvaluateScriptQueue.ipynb
+++ b/nightly/EvaluateScriptQueue.ipynb
@@ -9,9 +9,9 @@
    "source": [
     "# Set a range of dayobs values to search - \n",
     "day_obs_min = \"Today\"\n",
-    "day_obs_min = \"2024-11-25\"\n",
+    "#day_obs_min = \"2024-11-25\"\n",
     "day_obs_max = \"Today\"\n",
-    "day_obs_max = \"2024-11-26\"\n",
+    "#day_obs_max = \"2024-11-26\"\n",
     "time_order = 'newest first'"
    ]
   },
@@ -543,7 +543,7 @@
     "        # Strip excessive \\r\\n and \\n\\n from messages\n",
     "        messages['message_text'] = messages.apply(strip_rns, axis=1)\n",
     "        # Add a time index\n",
-    "        messages['time'] = messages.apply(make_time, args=[\"date_begin\"], axis=1)\n",
+    "        messages['time'] = messages.apply(make_time, args=[\"date_added\"], axis=1)\n",
     "        messages.set_index('time', inplace=True)\n",
     "        messages.index = messages.index.tz_localize(\"UTC\")\n",
     "        # Join the components and add \"Log\" explicitly\n",


### PR DESCRIPTION
Use date_added for timestamp for narrative log sequencing, instead of date_begin.