### PR TITLE
tickets/SP-2389: Make output of slurm batch jobs distinct

### DIFF
--- a/batch/prenight.sh
+++ b/batch/prenight.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #SBATCH --account=rubin:developers      # Account name
 #SBATCH --job-name=lsstcam_prenight_daily   # Job name
-#SBATCH --output=/sdf/data/rubin/shared/scheduler/schedview/sbatch/prenight.out # Output file (stdout)
-#SBATCH --error=/sdf/data/rubin/shared/scheduler/schedview/sbatch/prenight.err  # Error file (stderr)
+#SBATCH --output=/sdf/data/rubin/shared/scheduler/schedview/sbatch/prenight_%A_%a.out # Output file (stdout)
+#SBATCH --error=/sdf/data/rubin/shared/scheduler/schedview/sbatch/prenight_%A_%a.err  # Error file (stderr)
 #SBATCH --partition=milano              # Partition (queue) names
 #SBATCH --nodes=1                       # Number of nodes
 #SBATCH --ntasks=1                      # Number of tasks run in parallel

--- a/batch/scheduler_nightsum.sh
+++ b/batch/scheduler_nightsum.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #SBATCH --account=rubin:developers      # Account name
 #SBATCH --job-name=lsstcam_nightsum_daily   # Job name
-#SBATCH --output=/sdf/data/rubin/shared/scheduler/schedview/sbatch/scheduler_nightsum.out # Output file (stdout)
-#SBATCH --error=/sdf/data/rubin/shared/scheduler/schedview/sbatch/scheduler_nightsum.err  # Error file (stderr)
+#SBATCH --output=/sdf/data/rubin/shared/scheduler/schedview/sbatch/scheduler_nightsum_%A_%a.out # Output file (stdout)
+#SBATCH --error=/sdf/data/rubin/shared/scheduler/schedview/sbatch/scheduler_nightsum_%A_%a.err  # Error file (stderr)
 #SBATCH --partition=milano              # Partition (queue) names
 #SBATCH --nodes=1                       # Number of nodes
 #SBATCH --ntasks=1                      # Number of tasks run in parallel


### PR DESCRIPTION
Presently, new report generation job logs overwrite logs from older jobs. Instead, give each log a new name.