### PR TITLE
Move parameters cell to position 0 to fix Times Square parameter injection

### DIFF
--- a/nightly/plot_timeline.ipynb
+++ b/nightly/plot_timeline.ipynb
@@ -4,6 +4,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "date_start = \"\"   # YYYY-MM-DD or \"\" to use ndays\n",
+    "date_end   = \"\"   # YYYY-MM-DD exclusive, or \"\"\n",
+    "ndays      = 3*4*7    # number of observing nights\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,26 +322,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "# Configuration"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "date_start = \"\"   # YYYY-MM-DD or \"\" to use ndays\n",
-    "date_end   = \"\"   # YYYY-MM-DD exclusive, or \"\"\n",
-    "ndays      = 3*4*7    # number of observing nights\n"
    ]
   },
   {


### PR DESCRIPTION
Times Square injects parameters by replacing cell 0, not by the Papermill parameters tag convention. All other notebooks in this repo (GapLogs, FindPotentialBadVisits) follow this convention. Moving date_start/date_end/ndays to cell 0 and removing the parameters tag makes ?ndays= URL params work.